### PR TITLE
Added correct link from the GitHub repository

### DIFF
--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -9,7 +9,7 @@
     </div>
 
     <div class="github-link">
-      <a href="https://github.com" target="_blank">GitHub</a>
+      <a href="https://github.com/DavMunHer/TWDComponentsGallery" target="_blank">GitHub</a>
     </div>
   </div>
 </nav>


### PR DESCRIPTION
The GitHub link from the right side of the navbar was redirecting to the GitHub home page instead of the repository itself.

Now redirecting to this repository.