### PR TITLE
Hide sidebar clicking outside

### DIFF
--- a/src/app/components/component-view/component-view.component.html
+++ b/src/app/components/component-view/component-view.component.html
@@ -1,8 +1,8 @@
 <navbar />
-<responsive-menu (toggleSidebarView)="changeSidebarView($event)" />
+<responsive-menu [currentSidebarView]="sidebarStatus()" (toggleSidebarStatus)="changeSidebarView($event)" />
 <div class="content">
   <div class="sidebar-container">
-    <components-sidebar [showSidebar]="currentSidebarAction()" />
+    <components-sidebar [sidebarCurrentStatus]="sidebarStatus()" />
   </div>
   <div class="right-content">
     <header class="component-explorer-container">

--- a/src/app/components/component-view/component-view.component.html
+++ b/src/app/components/component-view/component-view.component.html
@@ -2,7 +2,7 @@
 <responsive-menu [currentSidebarView]="sidebarStatus()" (toggleSidebarStatus)="changeSidebarView($event)" />
 <div class="content">
   <div class="sidebar-container">
-    <components-sidebar [sidebarCurrentStatus]="sidebarStatus()" />
+    <components-sidebar (clickOutside)="hideSidebar($event)" [sidebarCurrentStatus]="sidebarStatus()" />
   </div>
   <div class="right-content">
     <header class="component-explorer-container">

--- a/src/app/components/component-view/component-view.component.ts
+++ b/src/app/components/component-view/component-view.component.ts
@@ -30,8 +30,8 @@ export class ComponentViewComponent implements OnInit {
   protected sidebarStatus = signal<'enabled' | 'disabled'>('disabled');
   private responsiveMenu = viewChild(ResponsiveMenuComponent, {read: ElementRef});
 
-  protected changeSidebarView(newView: 'enabled' | 'disabled') {
-    this.sidebarStatus.set(newView);
+  protected changeSidebarView(newStatus: 'enabled' | 'disabled') {
+    this.sidebarStatus.set(newStatus);
   }
 
   protected hideSidebar(target: HTMLElement) {

--- a/src/app/components/component-view/component-view.component.ts
+++ b/src/app/components/component-view/component-view.component.ts
@@ -28,16 +28,20 @@ export class ComponentViewComponent implements OnInit {
   protected showedInfo = signal<'docs' | 'playground'>(this.route.snapshot.params['showedInfo']);
 
   protected sidebarStatus = signal<'enabled' | 'disabled'>('disabled');
-  private responsiveMenu = viewChild(ResponsiveMenuComponent, {read: ElementRef});
+  private responsiveMenu = viewChild(ResponsiveMenuComponent);
 
   protected changeSidebarView(newStatus: 'enabled' | 'disabled') {
     this.sidebarStatus.set(newStatus);
   }
 
   protected hideSidebar(target: HTMLElement) {
-    if (!this.responsiveMenu()?.nativeElement.contains(target)) {
-      // We ignore the clickOutside when clicking in the menu component
-      this.sidebarStatus.set('disabled');
+    const responsiveMenuComponent = this.responsiveMenu();
+    if (responsiveMenuComponent) {
+      if (!responsiveMenuComponent.menuButtonContainer()?.nativeElement.contains(target)) {
+        // We ignore the clickOutside when clicking in the menu button container
+        // If this was not handled, it would result in an unexpected behaviour
+        this.sidebarStatus.set('disabled');
+      }
     }
   }
 

--- a/src/app/components/component-view/component-view.component.ts
+++ b/src/app/components/component-view/component-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnInit, signal } from '@angular/core';
+import { Component, ElementRef, inject, OnInit, signal, viewChild } from '@angular/core';
 import { SidebarComponent } from './sidebar/sidebar.component';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ComponentExplorerComponent } from './component-explorer/component-explorer.component';
@@ -7,25 +7,38 @@ import { AuthPlaygroundComponent } from './playgrounds/auth-playground/auth-play
 import { ComponentsInfoService } from '../../services/components-info.service';
 import { NavbarComponent } from '../navbar/navbar.component';
 import { ResponsiveMenuComponent } from './responsive-menu/responsive-menu.component';
+import { ClickOutsideDirective } from '../../directives/click-outside.directive';
 
 @Component({
   selector: 'app-component-view',
-  imports: [SidebarComponent, ComponentExplorerComponent, AuthDocsComponent, AuthPlaygroundComponent, NavbarComponent, ResponsiveMenuComponent],
+  imports: [
+    ClickOutsideDirective,
+    SidebarComponent, ComponentExplorerComponent,
+    AuthDocsComponent, AuthPlaygroundComponent,
+    NavbarComponent, ResponsiveMenuComponent
+  ],
   templateUrl: './component-view.component.html',
   styleUrl: './component-view.component.css'
 })
-export class ComponentViewComponent implements OnInit{
+export class ComponentViewComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private componentsInfoService = inject(ComponentsInfoService);
   protected componentName = signal<string>('');
   protected showedInfo = signal<'docs' | 'playground'>(this.route.snapshot.params['showedInfo']);
 
-  
-  protected currentSidebarAction = signal<'enable' | 'disable'>('disable');
+  protected sidebarStatus = signal<'enabled' | 'disabled'>('disabled');
+  private responsiveMenu = viewChild(ResponsiveMenuComponent, {read: ElementRef});
 
-  protected changeSidebarView(newView: 'enable' | 'disable') {
-    this.currentSidebarAction.set(newView);
+  protected changeSidebarView(newView: 'enabled' | 'disabled') {
+    this.sidebarStatus.set(newView);
+  }
+
+  protected hideSidebar(target: HTMLElement) {
+    if (!this.responsiveMenu()?.nativeElement.contains(target)) {
+      // We ignore the clickOutside when clicking in the menu component
+      this.sidebarStatus.set('disabled');
+    }
   }
 
 

--- a/src/app/components/component-view/responsive-menu/responsive-menu.component.html
+++ b/src/app/components/component-view/responsive-menu/responsive-menu.component.html
@@ -1,5 +1,5 @@
 <nav class="menu-container">
-    <div (click)="emitSidebarChange()" class="menu-content">
+    <div #buttonContainer (click)="emitSidebarChange()" class="menu-content">
         <svg class="menu-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
         </svg>

--- a/src/app/components/component-view/responsive-menu/responsive-menu.component.ts
+++ b/src/app/components/component-view/responsive-menu/responsive-menu.component.ts
@@ -1,4 +1,4 @@
-import { Component, output, signal } from '@angular/core';
+import { Component, input, output, signal } from '@angular/core';
 
 @Component({
   selector: 'responsive-menu',
@@ -7,16 +7,14 @@ import { Component, output, signal } from '@angular/core';
   styleUrl: './responsive-menu.component.css'
 })
 export class ResponsiveMenuComponent {
-  private currentSidebarView = signal<'enabled' | 'disabled'>('disabled');
-  public toggleSidebarView = output<'enable' | 'disable'>();
+  public currentSidebarView = input.required<'enabled' | 'disabled'>();
+  public toggleSidebarStatus = output<'enabled' | 'disabled'>();
 
   protected emitSidebarChange() {
     if (this.currentSidebarView() == 'disabled') {
-      this.toggleSidebarView.emit('enable');
-      this.currentSidebarView.set('enabled')
+      this.toggleSidebarStatus.emit('enabled');
     } else {
-      this.toggleSidebarView.emit('disable');
-      this.currentSidebarView.set('disabled')
+      this.toggleSidebarStatus.emit('disabled');
     }
   }
 }

--- a/src/app/components/component-view/responsive-menu/responsive-menu.component.ts
+++ b/src/app/components/component-view/responsive-menu/responsive-menu.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, output, signal } from '@angular/core';
+import { Component, ElementRef, input, output, viewChild } from '@angular/core';
 
 @Component({
   selector: 'responsive-menu',
@@ -9,6 +9,8 @@ import { Component, input, output, signal } from '@angular/core';
 export class ResponsiveMenuComponent {
   public currentSidebarView = input.required<'enabled' | 'disabled'>();
   public toggleSidebarStatus = output<'enabled' | 'disabled'>();
+
+  public menuButtonContainer = viewChild<ElementRef>('buttonContainer'); // Used in the parent component
 
   protected emitSidebarChange() {
     if (this.currentSidebarView() == 'disabled') {

--- a/src/app/components/component-view/sidebar/sidebar.component.html
+++ b/src/app/components/component-view/sidebar/sidebar.component.html
@@ -1,5 +1,5 @@
 <!-- The parent component will have to implement an aside tag including this component -->
-<aside class="sidebar-styles" [ngClass]="{'active': showSidebar() == 'enable'}">
+<aside class="sidebar-styles" [ngClass]="{'active': sidebarCurrentStatus() == 'enabled'}">
     <div class="sidebar-container">
         @for (componentInfo of componentsInfo; track $index) {
             @if (componentInfo.componentNameInUrl != 'coming soon') {

--- a/src/app/components/component-view/sidebar/sidebar.component.ts
+++ b/src/app/components/component-view/sidebar/sidebar.component.ts
@@ -4,10 +4,11 @@ import { CapitalizePipe } from '../../../pipes/capitalize.pipe';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ComponentMinInfo } from '../../../interfaces/component-min-info';
 import { NgClass } from '@angular/common';
+import { ClickOutsideDirective } from '../../../directives/click-outside.directive';
 
 @Component({
   selector: 'components-sidebar',
-  imports: [CapitalizePipe, RouterLink, NgClass],
+  imports: [CapitalizePipe, RouterLink, NgClass, ClickOutsideDirective],
   templateUrl: './sidebar.component.html',
   styleUrl: './sidebar.component.css'
 })
@@ -18,7 +19,7 @@ export class SidebarComponent implements OnInit {
   private route = inject(ActivatedRoute);
   protected selectedComponentNameInUrl = signal<string>(this.route.snapshot.params['name']);
 
-  public showSidebar = input.required<'enable' | 'disable'>();
+  public sidebarCurrentStatus = input.required<'enabled' | 'disabled'>();
 
   ngOnInit(): void {
     this.componentsInfo = this.componentsService.getComponentsMinInfo();
@@ -28,6 +29,7 @@ export class SidebarComponent implements OnInit {
       this.updateSelectedComponent();
     });
   }
+
 
   private updateSelectedComponent() {
     this.selectedComponentNameInUrl.set(this.route.snapshot.params['name']);

--- a/src/app/directives/click-outside.directive.spec.ts
+++ b/src/app/directives/click-outside.directive.spec.ts
@@ -1,0 +1,8 @@
+import { ClickOutsideDirective } from './click-outside.directive';
+
+describe('ClickOutsideDirective', () => {
+  it('should create an instance', () => {
+    const directive = new ClickOutsideDirective();
+    expect(directive).toBeTruthy();
+  });
+});

--- a/src/app/directives/click-outside.directive.ts
+++ b/src/app/directives/click-outside.directive.ts
@@ -1,0 +1,17 @@
+import { Directive, ElementRef, HostListener, inject, output } from '@angular/core';
+
+@Directive({
+  selector: '[clickOutside]'
+})
+export class ClickOutsideDirective {
+  private el = inject(ElementRef);
+  public clickOutside = output<HTMLElement>();
+
+  @HostListener('document:click', ['$event.target']) 
+  public onClick(target: HTMLElement) {
+    const clickedInside = this.el.nativeElement.contains(target);
+    if (!clickedInside) {
+      this.clickOutside.emit(target);
+    }
+  }
+}


### PR DESCRIPTION
This is mostly an upgrade for the user experience. 
Summary of this PR:
- Refactor of the previous code, now handling all the logic in the parent component (component-view) and sharing the status of the sidebar via inputs in the required child components
- When clicking outside of the sidebar itself, it hides now.
  - This behaviour excludes the menu button that allows the sidebar to be shown. If not handled, the sidebar would never be shown, as you clicked outside of the sidebar, which would automatically hide it before showing it.
