### PR TITLE
Responsive components view

### DIFF
--- a/src/app/components/component-view/component-explorer/component-explorer.component.css
+++ b/src/app/components/component-view/component-explorer/component-explorer.component.css
@@ -1,16 +1,41 @@
 :host {
-    --padding-x: 1em; 
+    --padding-x: 1em;
+    --inline-margin: 2rem;
+
+    --references-gap: 2rem;
+
+    @media (max-width: 1200px) {
+        --references-gap: 1.5rem;
+    }
+
+    @media (max-width: 800px) {
+        --references-gap: 1rem;
+    }
+
+    @media (max-width: 500px) {
+        --inline-margin: 15px;
+    }
+
+
 }
 
 .explorer-container {
     display: grid;
     grid-template-columns: auto 1fr;
-    margin-inline: 2rem;
+    margin-inline: var(--inline-margin);
     border-bottom: 1px solid #ccc;
+    max-width: calc(100vw - 30px);
+    overflow: scroll;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+        display: none;
+    }
+
 
     & .explorer-options {
         display: flex;
-        
+
         & .explorer-option {
             display: flex;
             align-items: center;
@@ -35,15 +60,18 @@
         justify-self: end;
         display: flex;
         align-items: center;
-        margin-right: 2rem;
-        gap: 2rem;
+        margin-left: 1.5rem;
 
-        & .component-reference { 
+        & .component-reference {
             text-align: center;
-            padding-inline: var(--padding-x);
+            padding-inline: var(--references-gap);
 
-            &:hover {
-                text-decoration: underline;
+            & .reference-anchor {
+                width: fit-content;
+
+                &:hover {
+                    text-decoration: underline;
+                }
             }
         }
     }

--- a/src/app/components/component-view/component-explorer/component-explorer.component.html
+++ b/src/app/components/component-view/component-explorer/component-explorer.component.html
@@ -12,12 +12,16 @@
         </a>
     </section>
     <section class="component-references">
-        <a class="component-reference" target="_blank" [href]="componentInfo()?.gitHubUrl">
-            <span>GitHub</span>
-        </a>
-        <a class="component-reference" target="_blank" [href]="componentInfo()?.npmPackageUrl">
-            <span>NPM</span>            
-        </a>
+        <div class="component-reference">
+            <a class="reference-anchor" target="_blank" [href]="componentInfo()?.gitHubUrl">
+                <span>GitHub</span>
+            </a>
+        </div>
+        <div class="component-reference">
+            <a class="reference-anchor" target="_blank" [href]="componentInfo()?.npmPackageUrl">
+                <span>NPM</span>            
+            </a>
+        </div>
     </section>
 
 </nav>

--- a/src/app/components/component-view/component-view.component.css
+++ b/src/app/components/component-view/component-view.component.css
@@ -1,13 +1,32 @@
 :host {
     --main-margin-x: 1rem;
-    
+
     --sidebar-container-width: 200px;
     --sidebar-position: 0;
     --left-margin: var(--sidebar-container-width);
+    --sidebar-separator-color: #aaa;
+
+
+    --sidebar-right-border: 1px solid var(--sidebar-separator-color);
+    --sidebar-border-radius: 0px;
+    --sidebar-padding-top: 2em;
+    --sidebar-background: transparent;
+    --sidebar-text-color: #000;
+    --active-component-background: #06e4;
+
 
     @media (max-width: 1200px) {
         --sidebar-position: calc(-1 * var(--sidebar-container-width));
         --left-margin: 0px;
+
+        --sidebar-background: color-mix(in srgb, #23252b 95%, #fff 5%);
+        --sidebar-right-border: none;
+        --sidebar-border-radius: 0px 15px 15px 0px;
+        --sidebar-padding-top: 1em;
+        --sidebar-text-color: #eee;
+
+        --active-component-background: color-mix(in srgb, #06e4 90%, #fff 10%);
+
     }
 }
 
@@ -28,4 +47,3 @@
         }
     }
 }
-

--- a/src/app/components/component-view/component-view.component.css
+++ b/src/app/components/component-view/component-view.component.css
@@ -10,12 +10,8 @@
         flex: 1;
         margin-left: var(--sidebar-container-width);
 
-        & .header {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            margin-block: 1rem;
-            margin-left: calc(var(--sidebar-container-width) * -1); /* For centering title to the middle of the screen */
+        & .component-explorer-container {
+            margin-top: 1em;
         }
 
         & .component-info {

--- a/src/app/components/component-view/component-view.component.css
+++ b/src/app/components/component-view/component-view.component.css
@@ -1,6 +1,14 @@
 :host {
     --main-margin-x: 1rem;
+    
     --sidebar-container-width: 200px;
+    --sidebar-position: 0;
+    --left-margin: var(--sidebar-container-width);
+
+    @media (max-width: 1200px) {
+        --sidebar-position: calc(-1 * var(--sidebar-container-width));
+        --left-margin: 0px;
+    }
 }
 
 .content {
@@ -8,7 +16,7 @@
 
     & .right-content {
         flex: 1;
-        margin-left: var(--sidebar-container-width);
+        margin-left: var(--left-margin);
 
         & .component-explorer-container {
             margin-top: 1em;

--- a/src/app/components/component-view/component-view.component.css
+++ b/src/app/components/component-view/component-view.component.css
@@ -1,6 +1,6 @@
 :host {
     --main-margin-x: 1rem;
-    --sidebar-container-width: 250px;
+    --sidebar-container-width: 200px;
 }
 
 .content {

--- a/src/app/components/component-view/component-view.component.css
+++ b/src/app/components/component-view/component-view.component.css
@@ -2,26 +2,23 @@
     --main-margin-x: 1rem;
 }
 
-.header {
+.content {
     display: flex;
-    justify-content: center;
-    align-items: center;
-    margin-block: 1rem;
-}
 
-.main {
-    display: grid;
-    grid-template-columns: auto 1fr;
-    overflow: scroll;
+    & .right-content {
+        flex: 1;
+        margin-left: 250px;
 
-    & .right-content .playground {
-        margin-inline: var(--main-margin-x);
-        margin-top: 0.5em;
-    }
+        & .header {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            margin-block: 1rem;
+        }
 
-    & .right-content .docs {
-        margin-inline: var(--main-margin-x);
-        margin-top: 0.5em;
+        & .component-info {
+            margin-inline: var(--main-margin-x);
+            margin-top: 0.5em;
+        }
     }
 }
-

--- a/src/app/components/component-view/component-view.component.css
+++ b/src/app/components/component-view/component-view.component.css
@@ -1,5 +1,6 @@
 :host {
     --main-margin-x: 1rem;
+    --sidebar-container-width: 250px;
 }
 
 .content {
@@ -7,13 +8,14 @@
 
     & .right-content {
         flex: 1;
-        margin-left: 250px;
+        margin-left: var(--sidebar-container-width);
 
         & .header {
             display: flex;
             justify-content: center;
             align-items: center;
             margin-block: 1rem;
+            margin-left: calc(var(--sidebar-container-width) * -1); /* For centering title to the middle of the screen */
         }
 
         & .component-info {
@@ -22,3 +24,4 @@
         }
     }
 }
+

--- a/src/app/components/component-view/component-view.component.html
+++ b/src/app/components/component-view/component-view.component.html
@@ -4,11 +4,10 @@
         <components-sidebar />
     </div>
     <div class="right-content">
-        <header class="header">
-            <h1>{{componentName() | capitalize}} Component</h1>
-        </header>
         <main>
-            <component-explorer />
+            <div class="component-explorer-container">
+                <component-explorer />
+            </div>
             <div class="component-info">
                 @if (showedInfo() == 'docs') {
                 <section class="docs">

--- a/src/app/components/component-view/component-view.component.html
+++ b/src/app/components/component-view/component-view.component.html
@@ -1,8 +1,8 @@
 <navbar />
-<responsive-menu (toggleSidebarView)="changeSidebarView($event)" />
+<responsive-menu [currentSidebarView]="sidebarStatus()" (toggleSidebarStatus)="changeSidebarView($event)" />
 <div class="content">
   <div class="sidebar-container">
-    <components-sidebar [showSidebar]="currentSidebarAction()" />
+    <components-sidebar (clickOutside)="hideSidebar($event)" [sidebarCurrentStatus]="sidebarStatus()" />
   </div>
   <div class="right-content">
     <header class="component-explorer-container">

--- a/src/app/components/component-view/component-view.component.html
+++ b/src/app/components/component-view/component-view.component.html
@@ -1,33 +1,34 @@
 <navbar />
+<responsive-menu/>
 <div class="content">
-    <div class="sidebar-container">
-        <components-sidebar />
-    </div>
-    <div class="right-content">
-        <header class="component-explorer-container">
-            <component-explorer />
-        </header>
-        <main>
-            <div class="component-info">
-                @if (showedInfo() == 'docs') {
-                <section class="docs">
-                    @switch (componentName()) {
-                    @case ('auth') {
-                    <auth-docs />
-                    }
-                    }
-                </section>
-                } @else {
-                <section class="playground">
-                    @switch (componentName()) {
-                    @case ('auth') {
-                    <auth-playground />
-                    }
-                    }
-                </section>
-                }
-            </div>
+  <div class="sidebar-container">
+    <components-sidebar />
+  </div>
+  <div class="right-content">
+    <header class="component-explorer-container">
+      <component-explorer />
+    </header>
+    <main>
+      <div class="component-info">
+        @if (showedInfo() == 'docs') {
+        <section class="docs">
+          @switch (componentName()) {
+            @case ('auth') {
+              <auth-docs />
+            }
+          }
+        </section>
+        } @else {
+        <section class="playground">
+          @switch (componentName()) {
+            @case ('auth') {
+              <auth-playground />
+            }
+          }
+        </section>
+        }
+      </div>
 
-        </main>
-    </div>
+    </main>
+  </div>
 </div>

--- a/src/app/components/component-view/component-view.component.html
+++ b/src/app/components/component-view/component-view.component.html
@@ -1,8 +1,8 @@
 <navbar />
-<responsive-menu/>
+<responsive-menu (toggleSidebarView)="changeSidebarView($event)" />
 <div class="content">
   <div class="sidebar-container">
-    <components-sidebar />
+    <components-sidebar [showSidebar]="currentSidebarAction()" />
   </div>
   <div class="right-content">
     <header class="component-explorer-container">

--- a/src/app/components/component-view/component-view.component.html
+++ b/src/app/components/component-view/component-view.component.html
@@ -14,7 +14,7 @@
         <section class="docs">
           @switch (componentName()) {
             @case ('auth') {
-              <auth-docs />
+              <!-- <auth-docs /> -->
             }
           }
         </section>
@@ -22,7 +22,7 @@
         <section class="playground">
           @switch (componentName()) {
             @case ('auth') {
-              <auth-playground />
+              <!-- <auth-playground /> -->
             }
           }
         </section>

--- a/src/app/components/component-view/component-view.component.html
+++ b/src/app/components/component-view/component-view.component.html
@@ -4,10 +4,10 @@
         <components-sidebar />
     </div>
     <div class="right-content">
+        <header class="component-explorer-container">
+            <component-explorer />
+        </header>
         <main>
-            <div class="component-explorer-container">
-                <component-explorer />
-            </div>
             <div class="component-info">
                 @if (showedInfo() == 'docs') {
                 <section class="docs">

--- a/src/app/components/component-view/component-view.component.html
+++ b/src/app/components/component-view/component-view.component.html
@@ -1,31 +1,34 @@
 <navbar />
-<header class="header">
-  <h1>{{componentName() | capitalize}} Component</h1>
-</header>
-<main>
-    <section class="main">
-        <components-sidebar/>
-        <div class="right-content">
-            <section class="component-explorer">
-                <component-explorer />
-            </section>
-            @if (showedInfo() == 'docs') {
+<div class="content">
+    <div class="sidebar-container">
+        <components-sidebar />
+    </div>
+    <div class="right-content">
+        <header class="header">
+            <h1>{{componentName() | capitalize}} Component</h1>
+        </header>
+        <main>
+            <component-explorer />
+            <div class="component-info">
+                @if (showedInfo() == 'docs') {
                 <section class="docs">
                     @switch (componentName()) {
-                        @case ('auth') {
-                            <auth-docs />
-                        }
+                    @case ('auth') {
+                    <auth-docs />
+                    }
                     }
                 </section>
-            } @else {
+                } @else {
                 <section class="playground">
                     @switch (componentName()) {
-                        @case ('auth') {
-                            <auth-playground />
-                        }
+                    @case ('auth') {
+                    <auth-playground />
+                    }
                     }
                 </section>
-            }
-        </div>
-    </section>
-</main>
+                }
+            </div>
+
+        </main>
+    </div>
+</div>

--- a/src/app/components/component-view/component-view.component.ts
+++ b/src/app/components/component-view/component-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnInit, signal } from '@angular/core';
+import { Component, ElementRef, inject, OnInit, signal, viewChild } from '@angular/core';
 import { SidebarComponent } from './sidebar/sidebar.component';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ComponentExplorerComponent } from './component-explorer/component-explorer.component';
@@ -7,25 +7,42 @@ import { AuthPlaygroundComponent } from './playgrounds/auth-playground/auth-play
 import { ComponentsInfoService } from '../../services/components-info.service';
 import { NavbarComponent } from '../navbar/navbar.component';
 import { ResponsiveMenuComponent } from './responsive-menu/responsive-menu.component';
+import { ClickOutsideDirective } from '../../directives/click-outside.directive';
 
 @Component({
   selector: 'app-component-view',
-  imports: [SidebarComponent, ComponentExplorerComponent, AuthDocsComponent, AuthPlaygroundComponent, NavbarComponent, ResponsiveMenuComponent],
+  imports: [
+    ClickOutsideDirective,
+    SidebarComponent, ComponentExplorerComponent,
+    AuthDocsComponent, AuthPlaygroundComponent,
+    NavbarComponent, ResponsiveMenuComponent
+  ],
   templateUrl: './component-view.component.html',
   styleUrl: './component-view.component.css'
 })
-export class ComponentViewComponent implements OnInit{
+export class ComponentViewComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private componentsInfoService = inject(ComponentsInfoService);
   protected componentName = signal<string>('');
   protected showedInfo = signal<'docs' | 'playground'>(this.route.snapshot.params['showedInfo']);
 
-  
-  protected currentSidebarAction = signal<'enable' | 'disable'>('disable');
+  protected sidebarStatus = signal<'enabled' | 'disabled'>('disabled');
+  private responsiveMenu = viewChild(ResponsiveMenuComponent);
 
-  protected changeSidebarView(newView: 'enable' | 'disable') {
-    this.currentSidebarAction.set(newView);
+  protected changeSidebarView(newStatus: 'enabled' | 'disabled') {
+    this.sidebarStatus.set(newStatus);
+  }
+
+  protected hideSidebar(target: HTMLElement) {
+    const responsiveMenuComponent = this.responsiveMenu();
+    if (responsiveMenuComponent) {
+      if (!responsiveMenuComponent.menuButtonContainer()?.nativeElement.contains(target)) {
+        // We ignore the clickOutside when clicking in the menu button container
+        // If this was not handled, it would result in an unexpected behaviour
+        this.sidebarStatus.set('disabled');
+      }
+    }
   }
 
 

--- a/src/app/components/component-view/component-view.component.ts
+++ b/src/app/components/component-view/component-view.component.ts
@@ -1,16 +1,16 @@
 import { Component, inject, OnInit, signal } from '@angular/core';
 import { SidebarComponent } from './sidebar/sidebar.component';
-import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
-import { CapitalizePipe } from '../../pipes/capitalize.pipe';
+import { ActivatedRoute, Router } from '@angular/router';
 import { ComponentExplorerComponent } from './component-explorer/component-explorer.component';
 import { AuthDocsComponent } from './docs/auth-docs/auth-docs.component';
 import { AuthPlaygroundComponent } from './playgrounds/auth-playground/auth-playground.component';
 import { ComponentsInfoService } from '../../services/components-info.service';
 import { NavbarComponent } from '../navbar/navbar.component';
+import { ResponsiveMenuComponent } from './responsive-menu/responsive-menu.component';
 
 @Component({
   selector: 'app-component-view',
-  imports: [SidebarComponent, CapitalizePipe, ComponentExplorerComponent, AuthDocsComponent, AuthPlaygroundComponent, NavbarComponent],
+  imports: [SidebarComponent, ComponentExplorerComponent, AuthDocsComponent, AuthPlaygroundComponent, NavbarComponent, ResponsiveMenuComponent],
   templateUrl: './component-view.component.html',
   styleUrl: './component-view.component.css'
 })

--- a/src/app/components/component-view/component-view.component.ts
+++ b/src/app/components/component-view/component-view.component.ts
@@ -21,6 +21,13 @@ export class ComponentViewComponent implements OnInit{
   protected componentName = signal<string>('');
   protected showedInfo = signal<'docs' | 'playground'>(this.route.snapshot.params['showedInfo']);
 
+  
+  protected currentSidebarAction = signal<'enable' | 'disable'>('disable');
+
+  protected changeSidebarView(newView: 'enable' | 'disable') {
+    this.currentSidebarAction.set(newView);
+  }
+
 
   ngOnInit(): void {
     this.updateComponentName();

--- a/src/app/components/component-view/responsive-menu/responsive-menu.component.css
+++ b/src/app/components/component-view/responsive-menu/responsive-menu.component.css
@@ -23,6 +23,7 @@
         padding-inline: 15px;
         padding-block: 5px;
         border-radius: 20px;
+        user-select: none;
 
         &:hover {
             background-color: color-mix(in srgb, var(--navbar-color) 90%, #fff 10%);

--- a/src/app/components/component-view/responsive-menu/responsive-menu.component.css
+++ b/src/app/components/component-view/responsive-menu/responsive-menu.component.css
@@ -1,0 +1,35 @@
+:host {
+    --navbar-color: rgba(35, 37, 43, 1);
+    --text-color: #fff;
+
+    --responsive-display: none;
+
+    @media (max-width: 1200px) {
+        --responsive-display: flex;
+    }
+}
+
+.menu-container {
+    display: var(--responsive-display);
+    background-color: var(--navbar-color);
+    justify-content: center;
+    align-items: center;
+    padding-block: 10px;
+    color: var(--text-color);
+
+    & .menu-content {
+        display: flex;
+        column-gap: 2px;
+        padding-inline: 15px;
+        padding-block: 5px;
+        border-radius: 20px;
+
+        &:hover {
+            background-color: color-mix(in srgb, var(--navbar-color) 90%, #fff 10%);
+        }
+
+        & .menu-icon {
+            width: 20px;
+        }
+    }
+}

--- a/src/app/components/component-view/responsive-menu/responsive-menu.component.html
+++ b/src/app/components/component-view/responsive-menu/responsive-menu.component.html
@@ -1,5 +1,5 @@
 <nav class="menu-container">
-    <div (click)="emitSidebarChange()" class="menu-content">
+    <div #buttonContainer (click)="emitSidebarChange()" class="menu-content">
         <svg class="menu-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
         </svg>

--- a/src/app/components/component-view/responsive-menu/responsive-menu.component.html
+++ b/src/app/components/component-view/responsive-menu/responsive-menu.component.html
@@ -1,5 +1,5 @@
 <nav class="menu-container">
-    <div class="menu-content">
+    <div (click)="emitSidebarChange()" class="menu-content">
         <svg class="menu-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
         </svg>

--- a/src/app/components/component-view/responsive-menu/responsive-menu.component.html
+++ b/src/app/components/component-view/responsive-menu/responsive-menu.component.html
@@ -1,0 +1,8 @@
+<nav class="menu-container">
+    <div class="menu-content">
+        <svg class="menu-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+        </svg>
+        <span>Menu</span>
+    </div>
+</nav>

--- a/src/app/components/component-view/responsive-menu/responsive-menu.component.spec.ts
+++ b/src/app/components/component-view/responsive-menu/responsive-menu.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ResponsiveMenuComponent } from './responsive-menu.component';
+
+describe('ResponsiveMenuComponent', () => {
+  let component: ResponsiveMenuComponent;
+  let fixture: ComponentFixture<ResponsiveMenuComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ResponsiveMenuComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ResponsiveMenuComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/component-view/responsive-menu/responsive-menu.component.ts
+++ b/src/app/components/component-view/responsive-menu/responsive-menu.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'responsive-menu',
+  imports: [],
+  templateUrl: './responsive-menu.component.html',
+  styleUrl: './responsive-menu.component.css'
+})
+export class ResponsiveMenuComponent {
+
+}

--- a/src/app/components/component-view/responsive-menu/responsive-menu.component.ts
+++ b/src/app/components/component-view/responsive-menu/responsive-menu.component.ts
@@ -13,8 +13,10 @@ export class ResponsiveMenuComponent {
   protected emitSidebarChange() {
     if (this.currentSidebarView() == 'disabled') {
       this.toggleSidebarView.emit('enable');
+      this.currentSidebarView.set('enabled')
     } else {
       this.toggleSidebarView.emit('disable');
+      this.currentSidebarView.set('disabled')
     }
   }
 }

--- a/src/app/components/component-view/responsive-menu/responsive-menu.component.ts
+++ b/src/app/components/component-view/responsive-menu/responsive-menu.component.ts
@@ -1,4 +1,4 @@
-import { Component, output, signal } from '@angular/core';
+import { Component, ElementRef, input, output, viewChild } from '@angular/core';
 
 @Component({
   selector: 'responsive-menu',
@@ -7,16 +7,16 @@ import { Component, output, signal } from '@angular/core';
   styleUrl: './responsive-menu.component.css'
 })
 export class ResponsiveMenuComponent {
-  private currentSidebarView = signal<'enabled' | 'disabled'>('disabled');
-  public toggleSidebarView = output<'enable' | 'disable'>();
+  public currentSidebarView = input.required<'enabled' | 'disabled'>();
+  public toggleSidebarStatus = output<'enabled' | 'disabled'>();
+
+  public menuButtonContainer = viewChild<ElementRef>('buttonContainer'); // Used in the parent component
 
   protected emitSidebarChange() {
     if (this.currentSidebarView() == 'disabled') {
-      this.toggleSidebarView.emit('enable');
-      this.currentSidebarView.set('enabled')
+      this.toggleSidebarStatus.emit('enabled');
     } else {
-      this.toggleSidebarView.emit('disable');
-      this.currentSidebarView.set('disabled')
+      this.toggleSidebarStatus.emit('disabled');
     }
   }
 }

--- a/src/app/components/component-view/responsive-menu/responsive-menu.component.ts
+++ b/src/app/components/component-view/responsive-menu/responsive-menu.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, output, signal } from '@angular/core';
 
 @Component({
   selector: 'responsive-menu',
@@ -7,5 +7,14 @@ import { Component } from '@angular/core';
   styleUrl: './responsive-menu.component.css'
 })
 export class ResponsiveMenuComponent {
+  private currentSidebarView = signal<'enabled' | 'disabled'>('disabled');
+  public toggleSidebarView = output<'enable' | 'disable'>();
 
+  protected emitSidebarChange() {
+    if (this.currentSidebarView() == 'disabled') {
+      this.toggleSidebarView.emit('enable');
+    } else {
+      this.toggleSidebarView.emit('disable');
+    }
+  }
 }

--- a/src/app/components/component-view/sidebar/sidebar.component.css
+++ b/src/app/components/component-view/sidebar/sidebar.component.css
@@ -1,12 +1,16 @@
 :host {
     --sidebar-x-margin: 1em;
     --sidebar-separator-color: #aaa; 
+    --navbar-height: 65px;
 }
 .sidebar-styles {
     border-right: 1px solid var(--sidebar-separator-color);
-    height: 100%;
     padding-top: 2em;
-    
+    position: fixed;
+    top: var(--navbar-height);
+    height: calc(100vh - var(--navbar-height));
+    width: 250px;
+
     & .sidebar-container {
         display: grid;
         grid-template-columns: 1fr;

--- a/src/app/components/component-view/sidebar/sidebar.component.css
+++ b/src/app/components/component-view/sidebar/sidebar.component.css
@@ -1,31 +1,27 @@
 :host {
     --sidebar-x-margin: 1em;
-    --sidebar-separator-color: #aaa;
     --navbar-height: 65px;
 }
 
 .sidebar-styles {
-    border-right: 1px solid var(--sidebar-separator-color);
-    padding-top: 2em;
+    /* Most of this variables are from the component-view component (father), for changing them all in the same media query */
+    border-right: var(--sidebar-right-border);
+    padding-top: var(--sidebar-padding-top);
     position: fixed;
     top: var(--navbar-height);
     left: var(--sidebar-position);
     height: calc(100vh - var(--navbar-height));
     width: var(--sidebar-container-width);
     overflow: scroll;
+    border-radius: var(--sidebar-border-radius);
+    background-color: var(--sidebar-background);
+    color: var(--sidebar-text-color);
+    z-index: 1000;
+
+    transition: left 0.3s ease;
 
     &.active {
         left: 0;
-        z-index: 1000;
-        background-color: color-mix(in srgb, #23252b 95%, #fff 5%);
-        border-right: none;
-        border-radius: 0px 15px;
-        padding-top: 1em;
-        color: #eee;
-
-        & .component-container.active {
-            background-color: color-mix(in srgb, #06e4 90%, #fff 10%) !important;
-        }
     }
 
     & .sidebar-container {
@@ -42,7 +38,7 @@
             align-items: center;
 
             &.active {
-                background-color: #06e4;
+                background-color: var(--active-component-background);
                 border-radius: 2rem;
                 font-weight: 800;
             }

--- a/src/app/components/component-view/sidebar/sidebar.component.css
+++ b/src/app/components/component-view/sidebar/sidebar.component.css
@@ -1,16 +1,17 @@
 :host {
     --sidebar-x-margin: 1em;
-    --sidebar-separator-color: #aaa; 
+    --sidebar-separator-color: #aaa;
     --navbar-height: 65px;
-    --sidebar-width: 200px;
 }
+
 .sidebar-styles {
     border-right: 1px solid var(--sidebar-separator-color);
     padding-top: 2em;
     position: fixed;
     top: var(--navbar-height);
+    left: var(--sidebar-position);
     height: calc(100vh - var(--navbar-height));
-    width: var(--sidebar-width);
+    width: var(--sidebar-container-width);
 
     & .sidebar-container {
         display: grid;

--- a/src/app/components/component-view/sidebar/sidebar.component.css
+++ b/src/app/components/component-view/sidebar/sidebar.component.css
@@ -12,6 +12,21 @@
     left: var(--sidebar-position);
     height: calc(100vh - var(--navbar-height));
     width: var(--sidebar-container-width);
+    overflow: scroll;
+
+    &.active {
+        left: 0;
+        z-index: 1000;
+        background-color: color-mix(in srgb, #23252b 95%, #fff 5%);
+        border-right: none;
+        border-radius: 0px 15px;
+        padding-top: 1em;
+        color: #eee;
+
+        & .component-container.active {
+            background-color: color-mix(in srgb, #06e4 90%, #fff 10%) !important;
+        }
+    }
 
     & .sidebar-container {
         display: grid;

--- a/src/app/components/component-view/sidebar/sidebar.component.css
+++ b/src/app/components/component-view/sidebar/sidebar.component.css
@@ -2,6 +2,7 @@
     --sidebar-x-margin: 1em;
     --sidebar-separator-color: #aaa; 
     --navbar-height: 65px;
+    --sidebar-width: 200px;
 }
 .sidebar-styles {
     border-right: 1px solid var(--sidebar-separator-color);
@@ -9,7 +10,7 @@
     position: fixed;
     top: var(--navbar-height);
     height: calc(100vh - var(--navbar-height));
-    width: 250px;
+    width: var(--sidebar-width);
 
     & .sidebar-container {
         display: grid;
@@ -27,7 +28,9 @@
             &.active {
                 background-color: #06e4;
                 border-radius: 2rem;
+                font-weight: 800;
             }
+
         }
     }
 }

--- a/src/app/components/component-view/sidebar/sidebar.component.html
+++ b/src/app/components/component-view/sidebar/sidebar.component.html
@@ -5,8 +5,8 @@
             @if (componentInfo.componentNameInUrl != 'coming soon') {
                 <a class="component-container" [ngClass]="{'active': componentInfo.componentNameInUrl == selectedComponentNameInUrl()}"
                 [routerLink]="['/components', componentInfo.componentNameInUrl , 'playground']">
-                <div >
-                    <span>{{componentInfo.name | capitalize}} Component</span>
+                <div>
+                    <span class="component-name">{{componentInfo.name | capitalize}}</span>
                 </div>
             </a>
             }

--- a/src/app/components/component-view/sidebar/sidebar.component.html
+++ b/src/app/components/component-view/sidebar/sidebar.component.html
@@ -1,5 +1,5 @@
 <!-- The parent component will have to implement an aside tag including this component -->
-<aside class="sidebar-styles">
+<aside class="sidebar-styles" [ngClass]="{'active': showSidebar() == 'enable'}">
     <div class="sidebar-container">
         @for (componentInfo of componentsInfo; track $index) {
             @if (componentInfo.componentNameInUrl != 'coming soon') {

--- a/src/app/components/component-view/sidebar/sidebar.component.html
+++ b/src/app/components/component-view/sidebar/sidebar.component.html
@@ -1,5 +1,5 @@
 <!-- The parent component will have to implement an aside tag including this component -->
-<aside class="sidebar-styles" [ngClass]="{'active': showSidebar() == 'enable'}">
+<aside class="sidebar-styles" [ngClass]="{'active': sidebarCurrentStatus() == 'enabled'}">
     <div class="sidebar-container">
         @for (componentInfo of componentsInfo; track $index) {
             @if (componentInfo.componentNameInUrl != 'coming soon') {

--- a/src/app/components/component-view/sidebar/sidebar.component.ts
+++ b/src/app/components/component-view/sidebar/sidebar.component.ts
@@ -4,10 +4,11 @@ import { CapitalizePipe } from '../../../pipes/capitalize.pipe';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ComponentMinInfo } from '../../../interfaces/component-min-info';
 import { NgClass } from '@angular/common';
+import { ClickOutsideDirective } from '../../../directives/click-outside.directive';
 
 @Component({
   selector: 'components-sidebar',
-  imports: [CapitalizePipe, RouterLink, NgClass],
+  imports: [CapitalizePipe, RouterLink, NgClass, ClickOutsideDirective],
   templateUrl: './sidebar.component.html',
   styleUrl: './sidebar.component.css'
 })
@@ -18,7 +19,7 @@ export class SidebarComponent implements OnInit {
   private route = inject(ActivatedRoute);
   protected selectedComponentNameInUrl = signal<string>(this.route.snapshot.params['name']);
 
-  public showSidebar = input.required<'enable' | 'disable'>();
+  public sidebarCurrentStatus = input.required<'enabled' | 'disabled'>();
 
   ngOnInit(): void {
     this.componentsInfo = this.componentsService.getComponentsMinInfo();
@@ -28,6 +29,7 @@ export class SidebarComponent implements OnInit {
       this.updateSelectedComponent();
     });
   }
+
 
   private updateSelectedComponent() {
     this.selectedComponentNameInUrl.set(this.route.snapshot.params['name']);

--- a/src/app/components/component-view/sidebar/sidebar.component.ts
+++ b/src/app/components/component-view/sidebar/sidebar.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnInit, signal } from '@angular/core';
+import { Component, inject, input, OnInit, signal } from '@angular/core';
 import { ComponentsInfoService } from '../../../services/components-info.service';
 import { CapitalizePipe } from '../../../pipes/capitalize.pipe';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
@@ -17,6 +17,8 @@ export class SidebarComponent implements OnInit {
   private router = inject(Router);
   private route = inject(ActivatedRoute);
   protected selectedComponentNameInUrl = signal<string>(this.route.snapshot.params['name']);
+
+  public showSidebar = input.required<'enable' | 'disable'>();
 
   ngOnInit(): void {
     this.componentsInfo = this.componentsService.getComponentsMinInfo();

--- a/src/app/components/navbar/navbar.component.css
+++ b/src/app/components/navbar/navbar.component.css
@@ -1,5 +1,6 @@
 .navbar {
   position: sticky;
+  height: 65px;
   top: 0;
   z-index: 1000;
   background-color: rgba(35, 37, 43, 1);

--- a/src/app/directives/click-outside.directive.spec.ts
+++ b/src/app/directives/click-outside.directive.spec.ts
@@ -1,0 +1,8 @@
+import { ClickOutsideDirective } from './click-outside.directive';
+
+describe('ClickOutsideDirective', () => {
+  it('should create an instance', () => {
+    const directive = new ClickOutsideDirective();
+    expect(directive).toBeTruthy();
+  });
+});

--- a/src/app/directives/click-outside.directive.ts
+++ b/src/app/directives/click-outside.directive.ts
@@ -1,0 +1,17 @@
+import { Directive, ElementRef, HostListener, inject, output } from '@angular/core';
+
+@Directive({
+  selector: '[clickOutside]'
+})
+export class ClickOutsideDirective {
+  private el = inject(ElementRef);
+  public clickOutside = output<HTMLElement>();
+
+  @HostListener('document:click', ['$event.target']) 
+  public onClick(target: HTMLElement) {
+    const clickedInside = this.el.nativeElement.contains(target);
+    if (!clickedInside) {
+      this.clickOutside.emit(target);
+    }
+  }
+}


### PR DESCRIPTION
Now the components-view component is fully responsive for all the devices.
Summary of what has been changed:
- Component-explorer is now limited to the width of the screen and if it overflows, you can access the rest of information by scrolling horizontally
- A new menu component, which is only shown for middle and small devices (Shown below the navbar).
  - This menu component is used for showing the sidebar that lists all the available components in the gallery.
  - A click outside directive that allows closing the sidebar for the small and medium devices.

- Some other code refactoring and improvements. 


This now allows to design and implement all the different embedded views (playground and docs) for all the components from the gallery.