### PR TITLE
Responsive view for the medium devices -> Tablets

### DIFF
--- a/src/app/components/component-view/playgrounds/auth-playground/auth-playground.component.css
+++ b/src/app/components/component-view/playgrounds/auth-playground/auth-playground.component.css
@@ -94,6 +94,7 @@
     }
 
     & .custom-section {
+      scroll-margin-top: 100px;
       grid-column-start: 1;
       grid-column-end: 2;
       grid-row-start: 2;

--- a/src/app/components/component-view/playgrounds/auth-playground/auth-playground.component.css
+++ b/src/app/components/component-view/playgrounds/auth-playground/auth-playground.component.css
@@ -1,12 +1,11 @@
 :host {
   --auth-component-distribution: 1fr;
-  --auth-component-position: auto;
   --playground-width: 95%;
   --section-row-gap: 8em;
 
   --grid-rows: 2;
   --grid-rows-display: repeat(var(--grid-rows), auto);
-  --grid-columns-display: 1fr var(--auth-component-distribution); 
+  --grid-columns-display: 1fr var(--auth-component-distribution);
 
 
   --component-column-start: 2;
@@ -16,7 +15,7 @@
 
   --component-width: 800px;
 
-  
+
   @media (max-height: 800px) {
     --section-row-gap: 2em;
   }
@@ -25,11 +24,6 @@
     /* For the desktop devices, center auth component to the center, as there might be more space available */
     --auth-component-position: center;
   }
-
-  @media (max-width: 1650px) {
-    --auth-component-distribution: auto;
-  }
-  
 
   @media (max-width: 1400px) {
     --playground-width: 80%;
@@ -76,6 +70,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  overflow: scroll;
 
   & .container {
     display: grid;
@@ -153,7 +148,7 @@
               & .apply-button {
                 background-color: #3498db;
               }
-              
+
               & .random-button {
                 text-align: center;
                 background-color: #ff6fff;
@@ -192,17 +187,18 @@
 
     }
 
-    &>.main-component {
+    & .main-component {
       grid-column-start: var(--component-column-start);
       grid-column-end: var(--component-column-end);
       grid-row-start: var(--component-row-start);
       grid-row-end: var(--component-row-end);
-      justify-self: var(--auth-component-position);
-      align-self: var(--auth-component-position);
+      display: flex;
+      justify-content: center;
+      align-items: center;
 
       /* Predifining component width and height for avoiding layout shift */
-      height: 500px;
-      width: var(--component-width);
+      min-height: 500px;
+      min-width: var(--component-width);
     }
 
   }

--- a/src/app/components/component-view/playgrounds/auth-playground/auth-playground.component.css
+++ b/src/app/components/component-view/playgrounds/auth-playground/auth-playground.component.css
@@ -14,6 +14,8 @@
   --component-row-start: 1;
   --component-row-end: 3;
 
+  --component-width: 800px;
+
   
   @media (max-height: 800px) {
     --section-row-gap: 2em;
@@ -39,6 +41,14 @@
     --component-column-end: 2;
     --component-row-start: 3;
     --component-row-end: 4;
+  }
+
+  @media (max-width: 800px) {
+    --component-width: 400px;
+  }
+
+  @media (max-width:450px) {
+    --component-width: 350px;
   }
 }
 
@@ -188,6 +198,10 @@
       grid-row-end: var(--component-row-end);
       justify-self: var(--auth-component-position);
       align-self: var(--auth-component-position);
+
+      /* Predifining component width and height for avoiding layout shift */
+      height: 500px;
+      width: var(--component-width);
     }
 
   }

--- a/src/app/components/component-view/playgrounds/auth-playground/auth-playground.component.css
+++ b/src/app/components/component-view/playgrounds/auth-playground/auth-playground.component.css
@@ -3,6 +3,17 @@
   --auth-component-position: auto;
   --playground-width: 95%;
   --section-row-gap: 8em;
+
+  --grid-rows: 2;
+  --grid-rows-display: repeat(var(--grid-rows), auto);
+  --grid-columns-display: 1fr var(--auth-component-distribution); 
+
+
+  --component-column-start: 2;
+  --component-column-end: 3;
+  --component-row-start: 1;
+  --component-row-end: 3;
+
   
   @media (max-height: 800px) {
     --section-row-gap: 2em;
@@ -19,7 +30,15 @@
   
 
   @media (max-width: 1400px) {
-    --playground-width: 100%;
+    --playground-width: 80%;
+    --grid-rows: 3;
+    --grid-columns: 1;
+    --grid-columns-display: 1fr;
+
+    --component-column-start: 1;
+    --component-column-end: 2;
+    --component-row-start: 3;
+    --component-row-end: 4;
   }
 }
 
@@ -50,16 +69,25 @@
 
   & .container {
     display: grid;
-    grid-template-columns: 1fr var(--auth-component-distribution);
-    grid-template-rows: auto auto;
+    grid-template-columns: var(--grid-columns-display);
+    grid-template-rows: var(--grid-rows-display);
     column-gap: 1em;
     row-gap: var(--section-row-gap);
     font-size: large;
     max-width: var(--playground-width);
 
-    /* & .introduction {} */
+    & .introduction {
+      grid-column-start: 1;
+      grid-column-end: 2;
+      grid-row-start: 1;
+      grid-row-end: 2;
+    }
 
     & .custom-section {
+      grid-column-start: 1;
+      grid-column-end: 2;
+      grid-row-start: 2;
+      grid-row-end: 3;
 
       & .custom-container {
         display: grid;
@@ -154,10 +182,10 @@
     }
 
     &>.main-component {
-      grid-column-end: span 2;
-      grid-row-end: span 2;
-      grid-column-start: 2;
-      grid-row-start: 1;
+      grid-column-start: var(--component-column-start);
+      grid-column-end: var(--component-column-end);
+      grid-row-start: var(--component-row-start);
+      grid-row-end: var(--component-row-end);
       justify-self: var(--auth-component-position);
       align-self: var(--auth-component-position);
     }

--- a/src/app/components/component-view/playgrounds/auth-playground/auth-playground.component.html
+++ b/src/app/components/component-view/playgrounds/auth-playground/auth-playground.component.html
@@ -12,6 +12,7 @@
           [href]="'/components/auth/playground#custom-section'">Customize</a> section
       </p>
     </article>
+
     <section id="custom-section" class="custom-section">
       <h2 class="section-title">Customize</h2>
       <div class="custom-container">

--- a/src/app/components/component-view/playgrounds/auth-playground/auth-playground.component.html
+++ b/src/app/components/component-view/playgrounds/auth-playground/auth-playground.component.html
@@ -8,11 +8,9 @@
         to
         some predefined templates or you could also define your own colors for each of the different elements from the
         component itself.
-        This can all be modified in the <a class="link"
-          [href]="'/components/auth/playground#custom-section'">Customize</a> section
+        This can all be modified in the <a href="components/auth/playground#custom-section" class="link">Customize</a> section.
       </p>
     </article>
-
     <section id="custom-section" class="custom-section">
       <h2 class="section-title">Customize</h2>
       <div class="custom-container">


### PR DESCRIPTION
Changed the view structure by only setting one column and dividing the content in three sections (rows):
- Introduction
- Custom section (for user interaction)
- Auth component itself

Also modified other details, such as centering the component in the middle of its container, scrolling to the customize section via the Customize link, etc.